### PR TITLE
Avoid duplication

### DIFF
--- a/ia_plugin.py
+++ b/ia_plugin.py
@@ -13,6 +13,7 @@ Examples:
 """
 from docopt import docopt
 
+# The module name must start with "ia_" in order for it to be recognized as a plugin.
 __title__ = __name__
 __version__ = '0.0.1'
 __url__ = 'https://github.com/jjjake/ia_plugin'

--- a/ia_plugin.py
+++ b/ia_plugin.py
@@ -13,13 +13,14 @@ Examples:
 """
 from docopt import docopt
 
-__title__ = 'ia_plugin'
+__title__ = __name__
 __version__ = '0.0.1'
 __url__ = 'https://github.com/jjjake/ia_plugin'
 __author__ = 'Jacob M. Johnson'
+__email__ = 'jake@archive.org'
 __license__ = 'AGPL 3'
 __copyright__ = 'Copyright 2015 Internet Archive'
-__all__ = ['ia_plugin']
+__all__ = [__title__]
 
 
 # `main()` must include two parameters: `argv` and `session`.

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,27 @@
 from setuptools import setup
 
-from ia_plugin import __version__
+from ia_plugin import \
+    __title__, __version__, __url__, __author__, __email__, __license__, __doc__
 
 
 setup(
-    name='ia_plugin',
+    name=__title__,
     version=__version__,
-    author='Jacob M. Johnson',
-    author_email='jake@archive.org',
-    url='https://github.com/jjjake/internetarchive-plugin',
-    license='AGPL 3',
-    description='An example ia-wrapper plugin.',
-    py_modules=['ia_plugin'],
+    author=__author__,
+    author_email=__email__,
+    url=__url__,
+    license=__license__,
+    description=__doc__.splitlines()[0],
+    py_modules=[__title__],
     install_requires=[
         'internetarchive',
     ],
     entry_points={
         'internetarchive.cli.plugins': [
-            'ia_plugin = ia_plugin',
+            __title__ + ' = ' + __title__,
         ],
         'console_scripts': [
-            'ia-plugin = ia_plugin:main',
+            __title__.replace('_', '-') + ' = ' + __title__ + ':main',
         ],
     },
     tests_require=[


### PR DESCRIPTION
There's no need to put the same metadata in two places. And suggesting that the name of the module should match the name of the tool is a good idea, too.